### PR TITLE
OpenCilk support, build script updates, README updates

### DIFF
--- a/MATLAB/fgltmake.m
+++ b/MATLAB/fgltmake.m
@@ -2,7 +2,7 @@ function fgltmake (what)
 %GBMAKE compile MATLAB interface for Fast Graphlet Transform
 %
 % Usage:
-%   fgtmake
+%   fgltmake
 %
 % See also mex, version.
 

--- a/README.md
+++ b/README.md
@@ -169,9 +169,6 @@ Xiaobai Sun<sup>2</sup>
 *Development of Julia and Python wrappers*:<br>
 Jason Barmparesos<sup>1</sup>, Konstantinos Kitsios<sup>1</sup>
 
-*OpenCilk port*:<br>
-Alexandros-Stavros Iliopoulos<sup>3</sup>
-
 *We also thank the following, for helpful comments and bug fixes*:<br>
 George Bisbas
 
@@ -179,6 +176,4 @@ George Bisbas
 <sup>1</sup> Department of Electrical and Computer Engineering,
 Aristotle University of Thessaloniki, Thessaloniki 54124, Greece<br>
 <sup>2</sup> Department of Computer Science, Duke University, Durham, NC
-27708, USA<br>
-<sup>3</sup> Computer Science and Artificial Intelligence Laboratory,
-Massachusetts Institute of Technology, Cambridge, MA 02139, USA
+27708, USA

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ with, and extension of, existing network analysis software.
 
 The `FGlT` library has been tested under Ubuntu 18.04 and macOS Catalina
 v10.15.6. The prerequisites is a `C++` compiler and the
-[Meson](https://mesonbuild.com) package with
-[Ninja](https://ninja-build.org) support. If the specified compiler
-supports `Cilk`, (GNU `g++-7`, `clang`, and Intel `icpc` versions prior to 2019, 
-and the new [`OpenCilk`](http://cilk.mit.edu) compiler), 
-the compiled program will run in parallel. 
+[Meson](https://mesonbuild.com) package with [Ninja](https://ninja-build.org)
+support. If the specified compiler supports `Cilk`, (e.g., the new
+[OpenCilk](opencilk.org) 1.0 `clang` compiler, GNU `g++-7`, Intel `icpc`
+versions prior to 2019, or Cilk Plus/LLVM `clang`), the compiled program will
+run in parallel.
 
 ## Prerequisites
 
@@ -67,30 +67,29 @@ You can install `meson` and `ninja` issuing
 
 ## Installation 
 
-After installing `meson` and `ninja`, you can install `FGlT`:
+After installing `meson` and `ninja`, you can build `FGlT` in a `build`
+directory:
 
     meson build
-    cd build
-    ninja
+    meson compile -C build
 
-To specify the `C++` compiler:
-
-    env CXX=g++-7 meson build
-    
-for example, to use the [OpenCilk](http://cilk.mit.edu) compiler,
-installed under `/usr/pkg/opencilk`, you can install `FGlT` using the command
+To specify the `C++` compiler, set the `CXX` environment variable when
+configuring the build directory. For example, to use the
+[OpenCilk](opencilk.org) compiler, installed under `/usr/pkg/opencilk`, you can
+install `FGlT` using the command
 
     env CXX=/usr/pkg/opencilk/bin/clang++ meson build
 
 If you wish to install system-wide the header files, libraries, and
-the `fglt` executable, issue:
+the `fglt` executable, issue (after building `FGlT`):
 
-    ninja install
+    meson install -C build
     
-*Note*: Depending on your setup, you might need `sudo` privileges for
-this operation.
+*Note*: Depending on your setup, you might need `sudo` privileges for this
+operation. To change the default installation prefix, specify the
+`-Dprefix=/path/to/install/dir` option when configuring the build directory.
 
-To generate the documentation (assuming `Doxygen` is installed on your
+To generate the documentation (assuming `doxygen` is installed on your
 machine):
 
     cd docs
@@ -169,11 +168,16 @@ Xiaobai Sun<sup>2</sup>
 *Development of Julia and Python wrappers*:<br>
 Jason Barmparesos<sup>1</sup>, Konstantinos Kitsios<sup>1</sup>
 
+*OpenCilk port*:<br>
+Alexandros-Stavros Iliopoulos<sup>3</sup>
+
 *We also thank the following, for helpful comments and bug fixes*:<br>
 George Bisbas
 
 
 <sup>1</sup> Department of Electrical and Computer Engineering,
-Aristotle University of Thessaloniki, Thessaloniki 54124, Greece\
+Aristotle University of Thessaloniki, Thessaloniki 54124, Greece<br>
 <sup>2</sup> Department of Computer Science, Duke University, Durham, NC
-27708, USA
+27708, USA<br>
+<sup>3</sup> Computer Science and Artificial Intelligence Laboratory,
+Massachusetts Institute of Technology, Cambridge, MA 02139, USA

--- a/lib/fglt.cpp
+++ b/lib/fglt.cpp
@@ -14,6 +14,9 @@
   #include <cilk/cilk.h>
   #include <cilk/cilk_api.h>
   #define FOR cilk_for
+  #ifdef CILKSCALE
+    #include <cilk/cilkscale.h>
+  #endif
 #else
   #define FOR for
 #endif
@@ -364,7 +367,10 @@ extern "C" int compute
 
   struct timeval timer_all = tic();
 
-  
+#ifdef CILKSCALE
+  wsp_t cs_start, cs_end;
+  cs_start = wsp_getworkspan();
+#endif
 
 
   // --- setup helpers
@@ -498,7 +504,15 @@ extern "C" int compute
   free(t02);
   free(c3);
 
+#ifdef CILKSCALE
+  cs_end = wsp_getworkspan();
+#endif
+
   printf( "Total elapsed time: %.4f sec\n", toc( timer_all ) );
+
+#ifdef CILKSCALE
+  wsp_dump( wsp_sub( cs_end, cs_start ), "FGLT computation" );
+#endif
   
   return 0;
   

--- a/meson.build
+++ b/meson.build
@@ -20,15 +20,15 @@ enable_cilkplus = not enable_opencilk \
                   and cc.has_header('cilk/cilk_api.h')
 
 if is_icpc
-  add_global_arguments(['-wd3947,3946,10006,3950'], language : 'cpp')
+  add_project_arguments(['-wd3947,3946,10006,3950'], language : 'cpp')
 endif
 
 if enable_opencilk
-  add_global_arguments(['-fopencilk', '-DHAVE_CILK_CILK_H'], language : 'cpp')
-  add_global_link_arguments(['-fopencilk'], language : 'cpp')
+  add_project_arguments(['-fopencilk', '-DHAVE_CILK_CILK_H'], language : 'cpp')
+  add_project_link_arguments(['-fopencilk'], language : 'cpp')
 elif enable_cilkplus
-  add_global_arguments(['-fcilkplus', '-DHAVE_CILK_CILK_H'], language : 'cpp')
-  add_global_link_arguments(['-lcilkrts'], language : 'cpp')
+  add_project_arguments(['-fcilkplus', '-DHAVE_CILK_CILK_H'], language : 'cpp')
+  add_project_link_arguments(['-lcilkrts'], language : 'cpp')
 endif
 
 # ========== OpenCilk tools

--- a/meson.build
+++ b/meson.build
@@ -114,9 +114,6 @@ if cpp_args_bench != []
                        install_rpath : get_option('prefix') / 'lib')
 endif
 
-# ========== tests
+# ========== tests & benchmark
 
-t1 = find_program( 'testdata/test_s6.sh')
-t2 = find_program( 'testdata/test_s12.sh')
-test('Validation on s6 synthetic graph', t1, args : e, is_parallel : false)
-test('Validation on s12 synthetic graph', t2, args : e, is_parallel : false)
+subdir('testdata')

--- a/meson.build
+++ b/meson.build
@@ -1,20 +1,84 @@
 project('fglt', 'cpp',
-        version : '1.0.0',
-        default_options: ['buildtype=release'] )
+        version : '1.0.1',
+        license : 'GPL-3.0-or-later',
+        meson_version : '>=0.49.0',
+        default_options: ['buildtype=release',
+                          'default_library=both'])
+
+# ========== compiler options
 
 cc = meson.get_compiler('cpp')
 
-is_icpc     = cc.get_id() == 'intel' or cc.get_id() == 'intel-cl'
-enable_cilk = cc.has_header('cilk/cilk.h') and ( is_icpc or cc.has_argument('-fcilkplus') )
+is_icpc         = cc.get_id() == 'intel' or cc.get_id() == 'intel-cl'
+enable_opencilk = not is_icpc \
+                  and cc.has_argument('-fopencilk') \
+                  and cc.has_header('cilk/cilk.h') \
+                  and cc.has_header('cilk/cilk_api.h')
+enable_cilkplus = not enable_opencilk \
+                  and (is_icpc or cc.has_argument('-fcilkplus')) \
+                  and cc.has_header('cilk/cilk.h') \
+                  and cc.has_header('cilk/cilk_api.h')
 
 if is_icpc
   add_global_arguments(['-wd3947,3946,10006,3950'], language : 'cpp')
 endif
 
-if enable_cilk
-   add_global_arguments(['-fcilkplus', '-DHAVE_CILK_CILK_H'], language : 'cpp')
-   add_global_link_arguments(['-lcilkrts'], language : 'cpp')
+if enable_opencilk
+  add_global_arguments(['-fopencilk', '-DHAVE_CILK_CILK_H'], language : 'cpp')
+  add_global_link_arguments(['-fopencilk'], language : 'cpp')
+elif enable_cilkplus
+  add_global_arguments(['-fcilkplus', '-DHAVE_CILK_CILK_H'], language : 'cpp')
+  add_global_link_arguments(['-lcilkrts'], language : 'cpp')
 endif
+
+# ========== OpenCilk tools
+
+cpp_args_cs     = []
+link_args_cs    = []
+str_cs          = ''
+cpp_args_bench  = []
+link_args_bench = []
+str_bench       = ''
+cpp_args_san    = []
+link_args_san   = []
+str_san         = ''
+
+if get_option('cilktool') == 'cilkscale' # ----- Cilkscale
+  if not enable_opencilk
+    warning('Cilkscale tool specified but not using OpenCilk compiler;'
+            + ' skipping instrumentation...')
+  else
+    cpp_args_cs     = ['-fcilktool=cilkscale', '-DCILKSCALE']
+    link_args_cs    = ['-fcilktool=cilkscale']
+    str_cs          = '-cilkscale'
+    cpp_args_bench  = ['-fcilktool=cilkscale-benchmark', '-DCILKSCALE']
+    link_args_bench = ['-fcilktool=cilkscale-benchmark']
+    str_bench       = str_cs + '-bench'
+  endif
+endif
+
+if get_option('cilktool') == 'cilksan' # ----- Cilksan
+  if not enable_opencilk
+    warning('Cilksan tool specified but not using OpenCilk compiler'
+            + ' skipping instrumentation...')
+  else
+    if not get_option('debug')
+      warning('Cilksan instrumentation without debug symbols!')
+    endif
+    cpp_args_san  = ['-fsanitize=cilk','-fno-stripmine',
+                     '-fno-vectorize','-fno-unroll-loops']
+    link_args_san = ['-fsanitize=cilk']
+    # FIXME There does not seem to be a way to add static-only arguments to
+    # build targets defined via `library()`.
+    # See also: https://github.com/mesonbuild/meson/issues/3304
+    if get_option('default_library') != 'static'
+      link_args_san += ['-shared-libasan']
+    endif
+    str_san = '-cilksan'
+  endif
+endif
+
+# ========== build targets
 
 fglthpp = configure_file(copy: true,
                          input: 'lib/fglt.hpp',
@@ -22,20 +86,37 @@ fglthpp = configure_file(copy: true,
 
 install_headers('lib/fglt.hpp')
 
-fglt_static = static_library('fglt', 'lib/fglt.cpp',
-                             install : true)
+fglt_lib = library('fglt' + str_cs + str_san, 'lib/fglt.cpp',
+                   cpp_args : cpp_args_cs + cpp_args_san,
+                   link_args : link_args_cs + link_args_san,
+                   install : true, install_dir : 'lib',
+                   soversion : '0')
 
-fglt_shared = shared_library('fglt', 'lib/fglt.cpp',
-                             soversion : '0',
-                             install : true)
+e = executable('fglt' + str_cs + str_san, 'src/fglt_mtx.cpp',
+               link_with : fglt_lib,
+               cpp_args : cpp_args_cs + cpp_args_san,
+               link_args : link_args_cs + link_args_san,
+               install : true,
+               install_rpath : get_option('prefix') / 'lib')
 
-e = executable('fglt', 'src/fglt_mtx.cpp',
-           link_with : fglt_shared,
-           install : true)
+#  Cilkscale-benchmark targets
+if cpp_args_bench != []
+  fglt_lib_bench = library('fglt' + str_bench, 'lib/fglt.cpp',
+                           cpp_args : cpp_args_bench,
+                           link_args : link_args_bench,
+                           install : true, install_dir : 'lib',
+                           soversion : '0')
+  e_bench = executable('fglt' + str_bench, 'src/fglt_mtx.cpp',
+                       link_with : fglt_lib_bench,
+                       cpp_args : cpp_args_bench,
+                       link_args : link_args_bench,
+                       install : true,
+                       install_rpath : get_option('prefix') / 'lib')
+endif
 
-# tests
+# ========== tests
 
 t1 = find_program( 'testdata/test_s6.sh')
 t2 = find_program( 'testdata/test_s12.sh')
-test('Validation on s6 synthetic graph', t1, is_parallel : false)
-test('Validation on s12 synthetic graph', t2, is_parallel : false)
+test('Validation on s6 synthetic graph', t1, args : e, is_parallel : false)
+test('Validation on s12 synthetic graph', t2, args : e, is_parallel : false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,5 @@
+option('cilktool',
+       type : 'combo',
+       choices : ['', 'none', 'cilkscale', 'cilksan'],
+       value : '',
+       description : 'OpenCilk instrumentation tool')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,3 +3,8 @@ option('cilktool',
        choices : ['', 'none', 'cilkscale', 'cilksan'],
        value : '',
        description : 'OpenCilk instrumentation tool')
+
+option('enable_benchmark',
+       type : 'boolean',
+       value : false,
+       description : 'Enable benchmark target? (Will download the `coPapersDBLP` graph from the SuiteSparse Matrix Collection)')

--- a/src/fglt_mtx.cpp
+++ b/src/fglt_mtx.cpp
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
 
   np = getWorkers();
 
-  std::cout << "Initiating fast graphlet transform for'" << filename
+  std::cout << "Initiating fast graphlet transform for '" << filename
             << "' using " << np << " threads." << std::endl;
   
   compute(f,fn,row,col,n,m,np);

--- a/testdata/download_benchmark_mtx.sh
+++ b/testdata/download_benchmark_mtx.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+MTX=${1:-coPapersDBLP.tar.gz}
+
+wget "https://suitesparse-collection-website.herokuapp.com/MM/DIMACS10/${MTX}"
+tar -xvzf "${MTX}" --strip 1

--- a/testdata/meson.build
+++ b/testdata/meson.build
@@ -1,0 +1,37 @@
+# ----- small tests
+
+t1 = find_program('test_s6.sh')
+t2 = find_program('test_s12.sh')
+test('Validation on s6 synthetic graph', t1, args : e, is_parallel : false)
+test('Validation on s12 synthetic graph', t2, args : e, is_parallel : false)
+
+# ----- benchmark
+
+if get_option('enable_benchmark')
+
+  id_bench = 'coPapersDBLP'
+
+  fs = import('fs')
+  if not fs.is_file(id_bench + '.mtx') # download and extract benchmark data
+
+    dl_mtx = find_program('download_benchmark_mtx.sh')
+    if not dl_mtx.found()
+      warning('Could not find `testdata/download_benchmark_mtx.sh`, ' +
+              'needed to download the benchmark adjacency matrix. ' +
+              'Disabling `benchmark` target.')
+    else
+      message('Downloading and extracting ' + id_bench + '.mtx ' +
+              'from the SuiteSparse matrix collection website.')
+      dl_mtx_result = run_command(dl_mtx, [id_bench + '.tar.gz'])
+      if dl_mtx_result.returncode() != 0
+        warning('Something went wrong while configuring the ' + id_bench + ' data. ' +
+                'The `benchmark` target may not work.')
+      endif
+    endif
+
+  endif
+
+  dat_bench = files(id_bench + '.mtx')
+  benchmark('suitesparse/coPapersDBLP', e, args : dat_bench)
+
+endif

--- a/testdata/test_s12.sh
+++ b/testdata/test_s12.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
+DIR_TESTDATA=$(cd "$(dirname "$0")" && pwd)
+
 FGLT=${1:-./fglt}
 
-${FGLT} ../testdata/s12.mtx
-diff freq_net.csv ../testdata/s12_freq_net_gold.csv
+${FGLT} "${DIR_TESTDATA}"/s12.mtx
+diff freq_net.csv "${DIR_TESTDATA}"/s12_freq_net_gold.csv

--- a/testdata/test_s12.sh
+++ b/testdata/test_s12.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-./fglt ../testdata/s12.mtx
+FGLT=${1:-./fglt}
+
+${FGLT} ../testdata/s12.mtx
 diff freq_net.csv ../testdata/s12_freq_net_gold.csv

--- a/testdata/test_s6.sh
+++ b/testdata/test_s6.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
+DIR_TESTDATA=$(cd "$(dirname "$0")" && pwd)
+
 FGLT=${1:-./fglt}
 
-${FGLT} ../testdata/s6.mtx
-diff freq_net.csv ../testdata/s6_freq_net_gold.csv
+${FGLT} "${DIR_TESTDATA}"/s6.mtx
+diff freq_net.csv "${DIR_TESTDATA}"/s6_freq_net_gold.csv

--- a/testdata/test_s6.sh
+++ b/testdata/test_s6.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-./fglt ../testdata/s6.mtx
+FGLT=${1:-./fglt}
+
+${FGLT} ../testdata/s6.mtx
 diff freq_net.csv ../testdata/s6_freq_net_gold.csv


### PR DESCRIPTION
This PR primarily updates the Meson build script to enable building FGlT with the OpenCilk compiler.  The PR edits are summarized below:

- Detect and support OpenCilk.
- Add option to instrument FGlT with OpenCilk's Cilksan or Cilkscale.
- Use the Meson built-in option `default_library` to choose static/shared library build.
- Remove implicit assumptions of build tree in Meson tests.
- Add `benchmark` target to Meson script.
- Update README to reflect OpenCilk support.

I changed the FGlT version from 1.0.0 to 1.0.1 in the Meson script, since this PR relaxes the system requirements of FGlT by adding support for the OpenCilk compiler.